### PR TITLE
enable mutltiple databases

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -70,6 +70,16 @@ resource "google_sql_database" "default" {
   depends_on = ["google_sql_database_instance.default"]
 }
 
+resource "google_sql_database" "additional_databases" {
+  count      = "${length(var.additional_databases)}"
+  project    = "${var.project_id}"
+  name       = "${lookup(var.additional_databases[count.index], "name")}"
+  charset    = "${lookup(var.additional_databases[count.index], "charset", "")}"
+  collation  = "${lookup(var.additional_databases[count.index], "collation", "")}"
+  instance   = "${google_sql_database_instance.default.name}"
+  depends_on = ["google_sql_database_instance.default"]
+}
+
 resource "random_id" "user-password" {
   keepers = {
     name = "${google_sql_database_instance.default.name}"

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -303,6 +303,11 @@ variable "db_collation" {
   default     = ""
 }
 
+variable "additional_databases" {
+  description = "The list of databases for the instacne"
+  default     = []
+}
+
 variable "user_name" {
   description = "The name of the default user"
   default     = "default"

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -70,6 +70,16 @@ resource "google_sql_database" "default" {
   depends_on = ["google_sql_database_instance.default"]
 }
 
+resource "google_sql_database" "additional_databases" {
+  count      = "${length(var.additional_databases)}"
+  project    = "${var.project_id}"
+  name       = "${lookup(var.additional_databases[count.index], "name")}"
+  charset    = "${lookup(var.additional_databases[count.index], "charset", "")}"
+  collation  = "${lookup(var.additional_databases[count.index], "collation", "")}"
+  instance   = "${google_sql_database_instance.default.name}"
+  depends_on = ["google_sql_database_instance.default"]
+}
+
 resource "random_id" "user-password" {
   keepers = {
     name = "${google_sql_database_instance.default.name}"

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -223,6 +223,11 @@ variable "db_collation" {
   default     = ""
 }
 
+variable "additional_databases" {
+  description = "The list of databases for the instacne"
+  default     = []
+}
+
 variable "user_name" {
   description = "The name of the default user"
   default     = "default"

--- a/test/fixtures/mysql-ha/main.tf
+++ b/test/fixtures/mysql-ha/main.tf
@@ -138,4 +138,12 @@ module "mysql" {
   db_name       = "${var.mysql_ha_name}"
   db_charset    = "utf8mb4"
   db_collation  = "utf8mb4_general_ci"
+
+  additional_databases = [
+    {
+      name      = "${var.mysql_ha_name}-additional"
+      charset   = "utf8mb4"
+      collation = "utf8mb4_general_ci"
+    }
+  ]
 }

--- a/test/fixtures/postgresql-ha/main.tf
+++ b/test/fixtures/postgresql-ha/main.tf
@@ -103,4 +103,12 @@ module "pg" {
   db_name       = "${var.pg_ha_name}"
   db_charset    = "UTF8"
   db_collation  = "en_US.UTF8"
+
+  additional_databases = [
+    {
+      name      = "${var.pg_ha_name}-additional"
+      charset   = "UTF8"
+      collation = "en_US.UTF8"
+    }
+  ]
 }


### PR DESCRIPTION
To support multiple databases, this commit adds the `additional_databases` argument in both modules. This doesn't break the backward compatibility.

@danisla @morgante 