### PR TITLE
Fix terraform list issue [WIP]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,21 +24,21 @@ resource "google_sql_database_instance" "default" {
   settings {
     tier                        = "${var.tier}"
     activation_policy           = "${var.activation_policy}"
-    authorized_gae_applications = ["${var.authorized_gae_applications}"]
+    authorized_gae_applications = "${var.authorized_gae_applications}"
     disk_autoresize             = "${var.disk_autoresize}"
-    backup_configuration        = ["${var.backup_configuration}"]
-    ip_configuration            = ["${var.ip_configuration}"]
-    location_preference         = ["${var.location_preference}"]
-    maintenance_window          = ["${var.maintenance_window}"]
+    backup_configuration        = "${var.backup_configuration}"
+    ip_configuration            = "${var.ip_configuration}"
+    location_preference         = "${var.location_preference}"
+    maintenance_window          = "${var.maintenance_window}"
     disk_size                   = "${var.disk_size}"
     disk_type                   = "${var.disk_type}"
     pricing_plan                = "${var.pricing_plan}"
     replication_type            = "${var.replication_type}"
-    database_flags              = ["${var.database_flags}"]
+    database_flags              = "${var.database_flags}"
     availability_type           = "${var.availability_type}"
   }
 
-  replica_configuration = ["${var.replica_configuration}"]
+  replica_configuration = "${var.replica_configuration}"
 }
 
 resource "google_sql_database" "default" {


### PR DESCRIPTION
Version used : 
Terraform v0.12.1
+ provider.google v2.8.0
+ provider.random v2.1.2

When hitting `terraform plan`, terraform complains about the shake of the data. The variables on `variable.tf` are a list that gets inserted into another list on `main.tf`.

**Error Message**

```
Error: Unsupported argument

  on db.tf line 131, in resource "google_sql_database_instance" "default":
 131:     location_preference         = "${var.location_preference}"

An argument named "location_preference" is not expected here. Did you mean to
define a block of type "location_preference"?
```
