### PR TITLE
avoid name conflicts when replicas recreation

### DIFF
--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -6,94 +6,96 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| activation\_policy | The activation policy for the master instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| additional\_databases | A list of databases to be created in your cluster | list | `<list>` | no |
-| additional\_users | A list of users to be created in your cluster | list | `<list>` | no |
-| authorized\_gae\_applications | The list of authorized App Engine project names | list | `<list>` | no |
-| backup\_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
-| create\_timeout | The optional timout that is applied to limit long database creates. | string | `"10m"` | no |
-| database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| database\_version | The database version to use | string | n/a | yes |
-| db\_charset | The charset for the default database | string | `""` | no |
-| db\_collation | The collation for the default database. Example: 'utf8_general_ci' | string | `""` | no |
-| db\_name | The name of the default database to create | string | `"default"` | no |
-| delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"10m"` | no |
-| disk\_autoresize | Configuration to increase storage size | string | `"true"` | no |
-| disk\_size | The disk size for the master instance | string | `"10"` | no |
-| disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |
-| failover\_replica | Specify true if the failover instance is required | string | `"false"` | no |
-| failover\_replica\_activation\_policy | The activation policy for the failover replica instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| failover\_replica\_configuration | The replica configuration for the failover replica instance. In order to create a failover instance, need to specify this argument. | map | `<map>` | no |
-| failover\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `"true"` | no |
-| failover\_replica\_database\_flags | The database flags for the failover replica instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| failover\_replica\_disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| failover\_replica\_disk\_size | The disk size for the failover replica instance. | string | `"10"` | no |
-| failover\_replica\_disk\_type | The disk type for the failover replica instance. | string | `"PD_SSD"` | no |
-| failover\_replica\_ip\_configuration | The ip configuration for the failover replica instances. | map | `<map>` | no |
-| failover\_replica\_maintenance\_window\_day | The day of week (1-7) for the failover replica instance maintenance. | string | `"1"` | no |
-| failover\_replica\_maintenance\_window\_hour | The hour of day (0-23) maintenance window for the failover replica instance maintenance. | string | `"23"` | no |
-| failover\_replica\_maintenance\_window\_update\_track | The update track of maintenance window for the failover replica instance maintenance. Can be either `canary` or `stable`. | string | `"canary"` | no |
-| failover\_replica\_pricing\_plan | The pricing plan for the failover replica instance. | string | `"PER_USE"` | no |
-| failover\_replica\_replication\_type | The replication type for the failover replica instance. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `"SYNCHRONOUS"` | no |
-| failover\_replica\_tier | The tier for the failover replica instance. | string | `""` | no |
-| failover\_replica\_user\_labels | The key/value labels for the failover replica instance. | map | `<map>` | no |
-| failover\_replica\_zone | The zone for the failover replica instance, it should be something like: `a`, `c`. | string | `""` | no |
-| ip\_configuration | The ip configuration for the master instance. | map | `<map>` | no |
-| maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | string | `"1"` | no |
-| maintenance\_window\_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `"23"` | no |
-| maintenance\_window\_update\_track | The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`. | string | `"canary"` | no |
-| name | The name of the Cloud SQL resources | string | n/a | yes |
-| pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
-| project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| read\_replica\_configuration | The replica configuration for use in all read replica instances. | map | `<map>` | no |
-| read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `"true"` | no |
-| read\_replica\_database\_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| read\_replica\_disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| read\_replica\_disk\_size | The disk size for the read replica instances. | string | `"10"` | no |
-| read\_replica\_disk\_type | The disk type for the read replica instances. | string | `"PD_SSD"` | no |
-| read\_replica\_ip\_configuration | The ip configuration for the read replica instances. | map | `<map>` | no |
-| read\_replica\_maintenance\_window\_day | The day of week (1-7) for the read replica instances maintenance. | string | `"1"` | no |
-| read\_replica\_maintenance\_window\_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `"23"` | no |
-| read\_replica\_maintenance\_window\_update\_track | The update track of maintenance window for the read replica instances maintenance. Can be either `canary` or `stable`. | string | `"canary"` | no |
-| read\_replica\_pricing\_plan | The pricing plan for the read replica instances. | string | `"PER_USE"` | no |
-| read\_replica\_replication\_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `"SYNCHRONOUS"` | no |
-| read\_replica\_size | The size of read replicas | string | `"0"` | no |
-| read\_replica\_tier | The tier for the read replica instances. | string | `""` | no |
-| read\_replica\_user\_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
-| read\_replica\_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `""` | no |
-| region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
-| tier | The tier for the master instance. | string | `"db-n1-standard-1"` | no |
-| update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
-| user\_host | The host for the default user | string | `"%"` | no |
-| user\_labels | The key/value labels for the master instances. | map | `<map>` | no |
-| user\_name | The name of the default user | string | `"default"` | no |
-| user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | n/a | yes |
+| activation_policy | The activation policy for the master instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| additional_databases | A list of databases to be created in your cluster | list | `<list>` | no |
+| additional_users | A list of users to be created in your cluster | list | `<list>` | no |
+| authorized_gae_applications | The list of authorized App Engine project names | list | `<list>` | no |
+| backup_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
+| create_timeout | The optional timout that is applied to limit long database creates. | string | `10m` | no |
+| database_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| database_version | The database version to use | string | - | yes |
+| db_charset | The charset for the default database | string | `` | no |
+| db_collation | The collation for the default database. Example: 'utf8_general_ci' | string | `` | no |
+| db_name | The name of the default database to create | string | `default` | no |
+| delete_timeout | The optional timout that is applied to limit long database deletes. | string | `10m` | no |
+| disk_autoresize | Configuration to increase storage size | string | `true` | no |
+| disk_size | The disk size for the master instance | string | `10` | no |
+| disk_type | The disk type for the master instance. | string | `PD_SSD` | no |
+| failover_replica | Specify true if the failover instance is required | string | `false` | no |
+| failover_replica_activation_policy | The activation policy for the failover replica instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| failover_replica_configuration | The replica configuration for the failover replica instance. In order to create a failover instance, need to specify this argument. | map | `<map>` | no |
+| failover_replica_crash_safe_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `true` | no |
+| failover_replica_database_flags | The database flags for the failover replica instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| failover_replica_disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| failover_replica_disk_size | The disk size for the failover replica instance. | string | `10` | no |
+| failover_replica_disk_type | The disk type for the failover replica instance. | string | `PD_SSD` | no |
+| failover_replica_ip_configuration | The ip configuration for the failover replica instances. | map | `<map>` | no |
+| failover_replica_maintenance_window_day | The day of week (1-7) for the failover replica instance maintenance. | string | `1` | no |
+| failover_replica_maintenance_window_hour | The hour of day (0-23) maintenance window for the failover replica instance maintenance. | string | `23` | no |
+| failover_replica_maintenance_window_update_track | The update track of maintenance window for the failover replica instance maintenance. Can be either `canary` or `stable`. | string | `canary` | no |
+| failover_replica_name_suffix | The optional suffix to add to the failover instance name | string | `` | no |
+| failover_replica_pricing_plan | The pricing plan for the failover replica instance. | string | `PER_USE` | no |
+| failover_replica_replication_type | The replication type for the failover replica instance. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `SYNCHRONOUS` | no |
+| failover_replica_tier | The tier for the failover replica instance. | string | `` | no |
+| failover_replica_user_labels | The key/value labels for the failover replica instance. | map | `<map>` | no |
+| failover_replica_zone | The zone for the failover replica instance, it should be something like: `a`, `c`. | string | `` | no |
+| ip_configuration | The ip configuration for the master instance. | map | `<map>` | no |
+| maintenance_window_day | The day of week (1-7) for the master instance maintenance. | string | `1` | no |
+| maintenance_window_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `23` | no |
+| maintenance_window_update_track | The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`. | string | `canary` | no |
+| name | The name of the Cloud SQL resources | string | - | yes |
+| pricing_plan | The pricing plan for the master instance. | string | `PER_USE` | no |
+| project_id | The project ID to manage the Cloud SQL resources | string | - | yes |
+| read_replica_activation_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| read_replica_configuration | The replica configuration for use in all read replica instances. | map | `<map>` | no |
+| read_replica_crash_safe_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `true` | no |
+| read_replica_database_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| read_replica_disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| read_replica_disk_size | The disk size for the read replica instances. | string | `10` | no |
+| read_replica_disk_type | The disk type for the read replica instances. | string | `PD_SSD` | no |
+| read_replica_ip_configuration | The ip configuration for the read replica instances. | map | `<map>` | no |
+| read_replica_maintenance_window_day | The day of week (1-7) for the read replica instances maintenance. | string | `1` | no |
+| read_replica_maintenance_window_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `23` | no |
+| read_replica_maintenance_window_update_track | The update track of maintenance window for the read replica instances maintenance. Can be either `canary` or `stable`. | string | `canary` | no |
+| read_replica_name_suffix | The optional suffix to add to the read instance name | string | `` | no |
+| read_replica_pricing_plan | The pricing plan for the read replica instances. | string | `PER_USE` | no |
+| read_replica_replication_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `SYNCHRONOUS` | no |
+| read_replica_size | The size of read replicas | string | `0` | no |
+| read_replica_tier | The tier for the read replica instances. | string | `` | no |
+| read_replica_user_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
+| read_replica_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `` | no |
+| region | The region of the Cloud SQL resources | string | `us-central1` | no |
+| tier | The tier for the master instance. | string | `db-n1-standard-1` | no |
+| update_timeout | The optional timout that is applied to limit long database updates. | string | `10m` | no |
+| user_host | The host for the default user | string | `%` | no |
+| user_labels | The key/value labels for the master instances. | map | `<map>` | no |
+| user_name | The name of the default user | string | `default` | no |
+| user_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `` | no |
+| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| failover-replica\_instance\_connection\_name | The connection name of the failover-replica instance to be used in connection strings |
-| failover-replica\_instance\_first\_ip\_address | The first IPv4 address of the addesses assigned for the failover-replica instance |
-| failover-replica\_instance\_name | The instance name for the failover replica instance |
-| failover-replica\_instance\_self\_link | The URI of the failover-replica instance |
-| failover-replica\_instance\_server\_ca\_cert | The CA certificate information used to connect to the failover-replica instance via SSL |
-| failover-replica\_instance\_service\_account\_email\_address | The service account email addresses assigned to the failover-replica instance |
-| generated\_user\_password | The auto generated default user password if not input password was provided |
-| instance\_connection\_name | The connection name of the master instance to be used in connection strings |
-| instance\_first\_ip\_address | The first IPv4 address of the addresses assigned for the master instance. |
-| instance\_ip\_address | The IPv4 address assigned for the master instance |
-| instance\_name | The instance name for the master instance |
-| instance\_self\_link | The URI of the master instance |
-| instance\_server\_ca\_cert | The CA certificate information used to connect to the SQL instance via SSL |
-| instance\_service\_account\_email\_address | The service account email address assigned to the master instance |
-| read\_replica\_instance\_names | The instance names for the read replica instances |
-| replicas\_instance\_connection\_names | The connection names of the replica instances to be used in connection strings |
-| replicas\_instance\_first\_ip\_addresses | The first IPv4 addresses of the addresses assigned for the replica instances |
-| replicas\_instance\_self\_links | The URIs of the replica instances |
-| replicas\_instance\_server\_ca\_certs | The CA certificates information used to connect to the replica instances via SSL |
-| replicas\_instance\_service\_account\_email\_addresses | The service account email addresses assigned to the replica instances |
+| failover-replica_instance_connection_name | The connection name of the failover-replica instance to be used in connection strings |
+| failover-replica_instance_first_ip_address | The first IPv4 address of the addesses assigned for the failover-replica instance |
+| failover-replica_instance_name | The instance name for the failover replica instance |
+| failover-replica_instance_self_link | The URI of the failover-replica instance |
+| failover-replica_instance_server_ca_cert | The CA certificate information used to connect to the failover-replica instance via SSL |
+| failover-replica_instance_service_account_email_address | The service account email addresses assigned to the failover-replica instance |
+| generated_user_password | The auto generated default user password if not input password was provided |
+| instance_connection_name | The connection name of the master instance to be used in connection strings |
+| instance_first_ip_address | The first IPv4 address of the addresses assigned for the master instance. |
+| instance_ip_address | The IPv4 address assigned for the master instance |
+| instance_name | The instance name for the master instance |
+| instance_self_link | The URI of the master instance |
+| instance_server_ca_cert | The CA certificate information used to connect to the SQL instance via SSL |
+| instance_service_account_email_address | The service account email address assigned to the master instance |
+| read_replica_instance_names | The instance names for the read replica instances |
+| replicas_instance_connection_names | The connection names of the replica instances to be used in connection strings |
+| replicas_instance_first_ip_addresses | The first IPv4 addresses of the addresses assigned for the replica instances |
+| replicas_instance_self_links | The URIs of the replica instances |
+| replicas_instance_server_ca_certs | The CA certificates information used to connect to the replica instances via SSL |
+| replicas_instance_service_account_email_addresses | The service account email addresses assigned to the replica instances |
 
 [^]: (autogen_docs_end)

--- a/modules/mysql/failover_replica.tf
+++ b/modules/mysql/failover_replica.tf
@@ -17,7 +17,7 @@
 resource "google_sql_database_instance" "failover-replica" {
   count                 = "${var.failover_replica ? 1 : 0}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-failover${var.failover_replica_name_suffix=="" ? "" : "-"}${var.failover_replica_name_suffix}"
+  name                  = "${var.name}-failover${var.failover_replica_name_suffix}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/mysql/failover_replica.tf
+++ b/modules/mysql/failover_replica.tf
@@ -17,7 +17,7 @@
 resource "google_sql_database_instance" "failover-replica" {
   count                 = "${var.failover_replica ? 1 : 0}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-failover"
+  name                  = "${var.name}-failover${var.failover_replica_name_suffix=="" ? "" : "-"}${var.failover_replica_name_suffix}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/mysql/read_replica.tf
+++ b/modules/mysql/read_replica.tf
@@ -32,7 +32,7 @@ locals {
 resource "google_sql_database_instance" "replicas" {
   count                 = "${var.read_replica_size}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-replica${count.index}${var.read_replica_name_suffix=="" ? "" : "-"}${var.read_replica_name_suffix}"
+  name                  = "${var.name}-replica${var.read_replica_name_suffix}${count.index}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/mysql/read_replica.tf
+++ b/modules/mysql/read_replica.tf
@@ -32,7 +32,7 @@ locals {
 resource "google_sql_database_instance" "replicas" {
   count                 = "${var.read_replica_size}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-replica${count.index}"
+  name                  = "${var.name}-replica${count.index}${var.read_replica_name_suffix=="" ? "" : "-"}${var.read_replica_name_suffix}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -124,6 +124,11 @@ variable "read_replica_configuration" {
   default     = {}
 }
 
+variable "read_replica_name_suffix" {
+  description = "The optional suffix to add to the read instance name"
+  default     = ""
+}
+
 variable "read_replica_size" {
   description = "The size of read replicas"
   default     = 0
@@ -209,6 +214,11 @@ variable "read_replica_ip_configuration" {
 variable "failover_replica" {
   description = "Specify true if the failover instance is required"
   default     = false
+}
+
+variable "failover_replica_name_suffix" {
+  description = "The optional suffix to add to the failover instance name"
+  default     = ""
 }
 
 variable "failover_replica_configuration" {

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -6,72 +6,73 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| activation\_policy | The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| additional\_databases | A list of databases to be created in your cluster | list | `<list>` | no |
-| additional\_users | A list of users to be created in your cluster | list | `<list>` | no |
-| authorized\_gae\_applications | The authorized gae applications for the Cloud SQL instances | list | `<list>` | no |
-| availability\_type | The availability type for the master instance.This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. | string | `"ZONAL"` | no |
-| backup\_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
-| create\_timeout | The optional timout that is applied to limit long database creates. | string | `"10m"` | no |
-| database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| database\_version | The database version to use | string | n/a | yes |
-| db\_charset | The charset for the default database | string | `""` | no |
-| db\_collation | The collation for the default database. Example: 'en_US.UTF8' | string | `""` | no |
-| db\_name | The name of the default database to create | string | `"default"` | no |
-| delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"10m"` | no |
-| disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| disk\_size | The disk size for the master instance. | string | `"10"` | no |
-| disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |
-| ip\_configuration | The ip configuration for the master instances. | map | `<map>` | no |
-| maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | string | `"1"` | no |
-| maintenance\_window\_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `"23"` | no |
-| maintenance\_window\_update\_track | The update track of maintenance window for the master instance maintenance.Can be either `canary` or `stable`. | string | `"canary"` | no |
-| name | The name of the Cloud SQL resources | string | n/a | yes |
-| pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
-| project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| read\_replica\_activation\_policy | The activation policy for the read replica instances.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| read\_replica\_availability\_type | The availability type for the read replica instances.This is only used to set up high availability for the PostgreSQL instances. Can be either `ZONAL` or `REGIONAL`. | string | `"ZONAL"` | no |
-| read\_replica\_configuration | The replica configuration for use in read replica | map | `<map>` | no |
-| read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `"true"` | no |
-| read\_replica\_database\_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| read\_replica\_disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| read\_replica\_disk\_size | The disk size for the read replica instances. | string | `"10"` | no |
-| read\_replica\_disk\_type | The disk type for the read replica instances. | string | `"PD_SSD"` | no |
-| read\_replica\_ip\_configuration | The ip configuration for the read instances. | map | `<map>` | no |
-| read\_replica\_maintenance\_window\_day | The day of week (1-7) for the read replica instances maintenance. | string | `"1"` | no |
-| read\_replica\_maintenance\_window\_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `"23"` | no |
-| read\_replica\_maintenance\_window\_update\_track | The update track of maintenance window for the read replica instances maintenance.Can be either `canary` or `stable`. | string | `"canary"` | no |
-| read\_replica\_pricing\_plan | The pricing plan for the read replica instances. | string | `"PER_USE"` | no |
-| read\_replica\_replication\_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `"SYNCHRONOUS"` | no |
-| read\_replica\_size | The size of read replicas | string | `"0"` | no |
-| read\_replica\_tier | The tier for the read replica instances. | string | `""` | no |
-| read\_replica\_user\_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
-| read\_replica\_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `""` | no |
-| region | The region of the Cloud SQL resources | string | `"us-central1"` | no |
-| tier | The tier for the master instance. | string | `"db-f1-micro"` | no |
-| update\_timeout | The optional timout that is applied to limit long database updates. | string | `"10m"` | no |
-| user\_labels | The key/value labels for the master instances. | map | `<map>` | no |
-| user\_name | The name of the default user | string | `"default"` | no |
-| user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | n/a | yes |
+| activation_policy | The activation policy for the master instance.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| additional_databases | A list of databases to be created in your cluster | list | `<list>` | no |
+| additional_users | A list of users to be created in your cluster | list | `<list>` | no |
+| authorized_gae_applications | The authorized gae applications for the Cloud SQL instances | list | `<list>` | no |
+| availability_type | The availability type for the master instance.This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. | string | `ZONAL` | no |
+| backup_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
+| create_timeout | The optional timout that is applied to limit long database creates. | string | `10m` | no |
+| database_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| database_version | The database version to use | string | - | yes |
+| db_charset | The charset for the default database | string | `` | no |
+| db_collation | The collation for the default database. Example: 'en_US.UTF8' | string | `` | no |
+| db_name | The name of the default database to create | string | `default` | no |
+| delete_timeout | The optional timout that is applied to limit long database deletes. | string | `10m` | no |
+| disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| disk_size | The disk size for the master instance. | string | `10` | no |
+| disk_type | The disk type for the master instance. | string | `PD_SSD` | no |
+| ip_configuration | The ip configuration for the master instances. | map | `<map>` | no |
+| maintenance_window_day | The day of week (1-7) for the master instance maintenance. | string | `1` | no |
+| maintenance_window_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `23` | no |
+| maintenance_window_update_track | The update track of maintenance window for the master instance maintenance.Can be either `canary` or `stable`. | string | `canary` | no |
+| name | The name of the Cloud SQL resources | string | - | yes |
+| pricing_plan | The pricing plan for the master instance. | string | `PER_USE` | no |
+| project_id | The project ID to manage the Cloud SQL resources | string | - | yes |
+| read_replica_activation_policy | The activation policy for the read replica instances.Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| read_replica_availability_type | The availability type for the read replica instances.This is only used to set up high availability for the PostgreSQL instances. Can be either `ZONAL` or `REGIONAL`. | string | `ZONAL` | no |
+| read_replica_configuration | The replica configuration for use in read replica | map | `<map>` | no |
+| read_replica_crash_safe_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `true` | no |
+| read_replica_database_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| read_replica_disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| read_replica_disk_size | The disk size for the read replica instances. | string | `10` | no |
+| read_replica_disk_type | The disk type for the read replica instances. | string | `PD_SSD` | no |
+| read_replica_ip_configuration | The ip configuration for the read instances. | map | `<map>` | no |
+| read_replica_maintenance_window_day | The day of week (1-7) for the read replica instances maintenance. | string | `1` | no |
+| read_replica_maintenance_window_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `23` | no |
+| read_replica_maintenance_window_update_track | The update track of maintenance window for the read replica instances maintenance.Can be either `canary` or `stable`. | string | `canary` | no |
+| read_replica_name_suffix | The optional suffix to add to the read instance name | string | `` | no |
+| read_replica_pricing_plan | The pricing plan for the read replica instances. | string | `PER_USE` | no |
+| read_replica_replication_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `SYNCHRONOUS` | no |
+| read_replica_size | The size of read replicas | string | `0` | no |
+| read_replica_tier | The tier for the read replica instances. | string | `` | no |
+| read_replica_user_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
+| read_replica_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `` | no |
+| region | The region of the Cloud SQL resources | string | `us-central1` | no |
+| tier | The tier for the master instance. | string | `db-f1-micro` | no |
+| update_timeout | The optional timout that is applied to limit long database updates. | string | `10m` | no |
+| user_labels | The key/value labels for the master instances. | map | `<map>` | no |
+| user_name | The name of the default user | string | `default` | no |
+| user_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `` | no |
+| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| generated\_user\_password | The auto generated default user password if not input password was provided |
-| instance\_address | The IPv4 addesses assigned for the master instance |
-| instance\_connection\_name | The connection name of the master instance to be used in connection strings |
-| instance\_first\_ip\_address | The first IPv4 address of the addresses assigned. |
-| instance\_name | The instance name for the master instance |
-| instance\_self\_link | The URI of the master instance |
-| instance\_server\_ca\_cert | The CA certificate information used to connect to the SQL instance via SSL |
-| instance\_service\_account\_email\_address | The service account email address assigned to the master instance |
-| read\_replica\_instance\_names | The instance names for the read replica instances |
-| replicas\_instance\_connection\_names | The connection names of the replica instances to be used in connection strings |
-| replicas\_instance\_ip\_addresses | The IPv4 addresses assigned for the replica instances |
-| replicas\_instance\_self\_links | The URIs of the replica instances |
-| replicas\_instance\_server\_ca\_certs | The CA certificates information used to connect to the replica instances via SSL |
-| replicas\_instance\_service\_account\_email\_addresses | The service account email addresses assigned to the replica instances |
+| generated_user_password | The auto generated default user password if not input password was provided |
+| instance_address | The IPv4 addesses assigned for the master instance |
+| instance_connection_name | The connection name of the master instance to be used in connection strings |
+| instance_first_ip_address | The first IPv4 address of the addresses assigned. |
+| instance_name | The instance name for the master instance |
+| instance_self_link | The URI of the master instance |
+| instance_server_ca_cert | The CA certificate information used to connect to the SQL instance via SSL |
+| instance_service_account_email_address | The service account email address assigned to the master instance |
+| read_replica_instance_names | The instance names for the read replica instances |
+| replicas_instance_connection_names | The connection names of the replica instances to be used in connection strings |
+| replicas_instance_ip_addresses | The IPv4 addresses assigned for the replica instances |
+| replicas_instance_self_links | The URIs of the replica instances |
+| replicas_instance_server_ca_certs | The CA certificates information used to connect to the replica instances via SSL |
+| replicas_instance_service_account_email_addresses | The service account email addresses assigned to the replica instances |
 
 [^]: (autogen_docs_end)

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -32,7 +32,7 @@ locals {
 resource "google_sql_database_instance" "replicas" {
   count                 = "${var.read_replica_size}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-replica${count.index}${var.read_replica_name_suffix=="" ? "" : "-"}${var.read_replica_name_suffix}"
+  name                  = "${var.name}-replica${var.read_replica_name_suffix}${count.index}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/postgresql/read_replica.tf
+++ b/modules/postgresql/read_replica.tf
@@ -32,7 +32,7 @@ locals {
 resource "google_sql_database_instance" "replicas" {
   count                 = "${var.read_replica_size}"
   project               = "${var.project_id}"
-  name                  = "${var.name}-replica${count.index}"
+  name                  = "${var.name}-replica${count.index}${var.read_replica_name_suffix=="" ? "" : "-"}${var.read_replica_name_suffix}"
   database_version      = "${var.database_version}"
   region                = "${var.region}"
   master_instance_name  = "${google_sql_database_instance.default.name}"

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -126,6 +126,11 @@ variable "read_replica_size" {
   default     = 0
 }
 
+variable "read_replica_name_suffix" {
+  description = "The optional suffix to add to the read instance name"
+  default     = ""
+}
+
 variable "read_replica_tier" {
   description = "The tier for the read replica instances."
   default     = ""

--- a/modules/private_service_access/README.md
+++ b/modules/private_service_access/README.md
@@ -16,19 +16,19 @@ that are connected to the same VPC.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| address | First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you. | string | `""` | no |
-| ip\_version | IP Version for the allocation. Can be IPV4 or IPV6. | string | `""` | no |
+| address | First IP address of the IP range to allocate to CLoud SQL instances and other Private Service Access services. If not set, GCP will pick a valid one for you. | string | `` | no |
+| ip_version | IP Version for the allocation. Can be IPV4 or IPV6. | string | `` | no |
 | labels | The key/value labels for the IP range allocated to the peered network. | map | `<map>` | no |
-| prefix\_length | Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16. | string | `"16"` | no |
-| project\_id | The project ID of the VPC network to peer. This can be a shared VPC host projec. | string | n/a | yes |
-| vpc\_network | Name of the VPC network to peer. | string | n/a | yes |
+| prefix_length | Prefix length of the IP range reserved for Cloud SQL instances and other Private Service Access services. Defaults to /16. | string | `16` | no |
+| project_id | The project ID of the VPC network to peer. This can be a shared VPC host projec. | string | - | yes |
+| vpc_network | Name of the VPC network to peer. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | address | First IP of the reserved range. |
-| google\_compute\_global\_address\_name | URL of the reserved range. |
-| peering\_completed | Use for enforce ordering between resource creation |
+| google_compute_global_address_name | URL of the reserved range. |
+| peering_completed | Use for enforce ordering between resource creation |
 
 [^]: (autogen_docs_end)

--- a/modules/safer_mysql/README.md
+++ b/modules/safer_mysql/README.md
@@ -165,86 +165,88 @@ mysql -S $HOME/mysql_sockets/myproject:region:instance -u user -p
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| activation\_policy | The activation policy for the master instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| additional\_databases | A list of databases to be created in your cluster | list | `<list>` | no |
-| additional\_users | A list of users to be created in your cluster | list | `<list>` | no |
-| assign\_public\_ip | Set to true if the master instance should also have a public IP (less secure). | string | `"false"` | no |
-| authorized\_gae\_applications | The list of authorized App Engine project names | list | `<list>` | no |
-| backup\_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
-| create\_timeout | The optional timout that is applied to limit long database creates. | string | `"15m"` | no |
-| database\_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| database\_version | The database version to use | string | n/a | yes |
-| db\_charset | The charset for the default database | string | `""` | no |
-| db\_collation | The collation for the default database. Example: 'utf8_general_ci' | string | `""` | no |
-| db\_name | The name of the default database to create | string | `"default"` | no |
-| delete\_timeout | The optional timout that is applied to limit long database deletes. | string | `"15m"` | no |
-| disk\_autoresize | Configuration to increase storage size | string | `"true"` | no |
-| disk\_size | The disk size for the master instance | string | `"10"` | no |
-| disk\_type | The disk type for the master instance. | string | `"PD_SSD"` | no |
-| failover\_replica | Specify true if the failover instance is required | string | `"false"` | no |
-| failover\_replica\_activation\_policy | The activation policy for the failover replica instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| failover\_replica\_configuration | The replica configuration for the failover replica instance. In order to create a failover instance, need to specify this argument. | map | `<map>` | no |
-| failover\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `"true"` | no |
-| failover\_replica\_database\_flags | The database flags for the failover replica instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| failover\_replica\_disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| failover\_replica\_disk\_size | The disk size for the failover replica instance. | string | `"10"` | no |
-| failover\_replica\_disk\_type | The disk type for the failover replica instance. | string | `"PD_SSD"` | no |
-| failover\_replica\_maintenance\_window\_day | The day of week (1-7) for the failover replica instance maintenance. | string | `"1"` | no |
-| failover\_replica\_maintenance\_window\_hour | The hour of day (0-23) maintenance window for the failover replica instance maintenance. | string | `"23"` | no |
-| failover\_replica\_maintenance\_window\_update\_track | The update track of maintenance window for the failover replica instance maintenance. Can be either `canary` or `stable`. | string | `"canary"` | no |
-| failover\_replica\_pricing\_plan | The pricing plan for the failover replica instance. | string | `"PER_USE"` | no |
-| failover\_replica\_replication\_type | The replication type for the failover replica instance. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `"SYNCHRONOUS"` | no |
-| failover\_replica\_tier | The tier for the failover replica instance. | string | `""` | no |
-| failover\_replica\_user\_labels | The key/value labels for the failover replica instance. | map | `<map>` | no |
-| failover\_replica\_zone | The zone for the failover replica instance, it should be something like: `a`, `c`. | string | `""` | no |
-| maintenance\_window\_day | The day of week (1-7) for the master instance maintenance. | string | `"1"` | no |
-| maintenance\_window\_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `"23"` | no |
-| maintenance\_window\_update\_track | The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`. | string | `"stable"` | no |
-| name | The name of the Cloud SQL resources | string | n/a | yes |
-| peering\_completed | Optional. This is used to ensure that resources are created in the proper order when using private IPs and service network peering. | string | `""` | no |
-| pricing\_plan | The pricing plan for the master instance. | string | `"PER_USE"` | no |
-| project\_id | The project ID to manage the Cloud SQL resources | string | n/a | yes |
-| read\_replica\_activation\_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `"ALWAYS"` | no |
-| read\_replica\_configuration | The replica configuration for use in all read replica instances. | map | `<map>` | no |
-| read\_replica\_crash\_safe\_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `"true"` | no |
-| read\_replica\_database\_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
-| read\_replica\_disk\_autoresize | Configuration to increase storage size. | string | `"true"` | no |
-| read\_replica\_disk\_size | The disk size for the read replica instances. | string | `"10"` | no |
-| read\_replica\_disk\_type | The disk type for the read replica instances. | string | `"PD_SSD"` | no |
-| read\_replica\_maintenance\_window\_day | The day of week (1-7) for the read replica instances maintenance. | string | `"1"` | no |
-| read\_replica\_maintenance\_window\_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `"23"` | no |
-| read\_replica\_maintenance\_window\_update\_track | The update track of maintenance window for the read replica instances maintenance. Can be either `canary` or `stable`. | string | `"canary"` | no |
-| read\_replica\_pricing\_plan | The pricing plan for the read replica instances. | string | `"PER_USE"` | no |
-| read\_replica\_replication\_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `"SYNCHRONOUS"` | no |
-| read\_replica\_size | The size of read replicas | string | `"0"` | no |
-| read\_replica\_tier | The tier for the read replica instances. | string | `""` | no |
-| read\_replica\_user\_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
-| read\_replica\_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `""` | no |
-| region | The region of the Cloud SQL resources | string | n/a | yes |
-| tier | The tier for the master instance. | string | `"db-n1-standard-1"` | no |
-| update\_timeout | The optional timout that is applied to limit long database updates. | string | `"15m"` | no |
-| user\_labels | The key/value labels for the master instances. | map | `<map>` | no |
-| user\_name | The name of the default user | string | `"default"` | no |
-| user\_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `""` | no |
-| vpc\_network | Existing VPC network to which instances are connected. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access. | string | n/a | yes |
-| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | n/a | yes |
+| activation_policy | The activation policy for the master instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| additional_databases | A list of databases to be created in your cluster | list | `<list>` | no |
+| additional_users | A list of users to be created in your cluster | list | `<list>` | no |
+| assign_public_ip | Set to true if the master instance should also have a public IP (less secure). | string | `false` | no |
+| authorized_gae_applications | The list of authorized App Engine project names | list | `<list>` | no |
+| backup_configuration | The backup configuration block of the Cloud SQL resources This argument will be passed through the master instance directrly.<br><br>See [more details](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html). | map | `<map>` | no |
+| create_timeout | The optional timout that is applied to limit long database creates. | string | `15m` | no |
+| database_flags | The database flags for the master instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| database_version | The database version to use | string | - | yes |
+| db_charset | The charset for the default database | string | `` | no |
+| db_collation | The collation for the default database. Example: 'utf8_general_ci' | string | `` | no |
+| db_name | The name of the default database to create | string | `default` | no |
+| delete_timeout | The optional timout that is applied to limit long database deletes. | string | `15m` | no |
+| disk_autoresize | Configuration to increase storage size | string | `true` | no |
+| disk_size | The disk size for the master instance | string | `10` | no |
+| disk_type | The disk type for the master instance. | string | `PD_SSD` | no |
+| failover_replica | Specify true if the failover instance is required | string | `false` | no |
+| failover_replica_activation_policy | The activation policy for the failover replica instance. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| failover_replica_configuration | The replica configuration for the failover replica instance. In order to create a failover instance, need to specify this argument. | map | `<map>` | no |
+| failover_replica_crash_safe_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `true` | no |
+| failover_replica_database_flags | The database flags for the failover replica instance. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| failover_replica_disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| failover_replica_disk_size | The disk size for the failover replica instance. | string | `10` | no |
+| failover_replica_disk_type | The disk type for the failover replica instance. | string | `PD_SSD` | no |
+| failover_replica_maintenance_window_day | The day of week (1-7) for the failover replica instance maintenance. | string | `1` | no |
+| failover_replica_maintenance_window_hour | The hour of day (0-23) maintenance window for the failover replica instance maintenance. | string | `23` | no |
+| failover_replica_maintenance_window_update_track | The update track of maintenance window for the failover replica instance maintenance. Can be either `canary` or `stable`. | string | `canary` | no |
+| failover_replica_name_suffix | The optional suffix to add to the failover instance name | string | `` | no |
+| failover_replica_pricing_plan | The pricing plan for the failover replica instance. | string | `PER_USE` | no |
+| failover_replica_replication_type | The replication type for the failover replica instance. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `SYNCHRONOUS` | no |
+| failover_replica_tier | The tier for the failover replica instance. | string | `` | no |
+| failover_replica_user_labels | The key/value labels for the failover replica instance. | map | `<map>` | no |
+| failover_replica_zone | The zone for the failover replica instance, it should be something like: `a`, `c`. | string | `` | no |
+| maintenance_window_day | The day of week (1-7) for the master instance maintenance. | string | `1` | no |
+| maintenance_window_hour | The hour of day (0-23) maintenance window for the master instance maintenance. | string | `23` | no |
+| maintenance_window_update_track | The update track of maintenance window for the master instance maintenance. Can be either `canary` or `stable`. | string | `stable` | no |
+| name | The name of the Cloud SQL resources | string | - | yes |
+| peering_completed | Optional. This is used to ensure that resources are created in the proper order when using private IPs and service network peering. | string | `` | no |
+| pricing_plan | The pricing plan for the master instance. | string | `PER_USE` | no |
+| project_id | The project ID to manage the Cloud SQL resources | string | - | yes |
+| read_replica_activation_policy | The activation policy for the read replica instances. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`. | string | `ALWAYS` | no |
+| read_replica_configuration | The replica configuration for use in all read replica instances. | map | `<map>` | no |
+| read_replica_crash_safe_replication | The crash safe replication is to indicates when crash-safe replication flags are enabled. | string | `true` | no |
+| read_replica_database_flags | The database flags for the read replica instances. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | list | `<list>` | no |
+| read_replica_disk_autoresize | Configuration to increase storage size. | string | `true` | no |
+| read_replica_disk_size | The disk size for the read replica instances. | string | `10` | no |
+| read_replica_disk_type | The disk type for the read replica instances. | string | `PD_SSD` | no |
+| read_replica_maintenance_window_day | The day of week (1-7) for the read replica instances maintenance. | string | `1` | no |
+| read_replica_maintenance_window_hour | The hour of day (0-23) maintenance window for the read replica instances maintenance. | string | `23` | no |
+| read_replica_maintenance_window_update_track | The update track of maintenance window for the read replica instances maintenance. Can be either `canary` or `stable`. | string | `canary` | no |
+| read_replica_name_suffix | The optional suffix to add to the read instance name | string | `` | no |
+| read_replica_pricing_plan | The pricing plan for the read replica instances. | string | `PER_USE` | no |
+| read_replica_replication_type | The replication type for read replica instances. Can be one of ASYNCHRONOUS or SYNCHRONOUS. | string | `SYNCHRONOUS` | no |
+| read_replica_size | The size of read replicas | string | `0` | no |
+| read_replica_tier | The tier for the read replica instances. | string | `` | no |
+| read_replica_user_labels | The key/value labels for the read replica instances. | map | `<map>` | no |
+| read_replica_zones | The zones for the read replica instancess, it should be something like: `a,b,c`. Given zones are used rotationally for creating read replicas. | string | `` | no |
+| region | The region of the Cloud SQL resources | string | - | yes |
+| tier | The tier for the master instance. | string | `db-n1-standard-1` | no |
+| update_timeout | The optional timout that is applied to limit long database updates. | string | `15m` | no |
+| user_labels | The key/value labels for the master instances. | map | `<map>` | no |
+| user_name | The name of the default user | string | `default` | no |
+| user_password | The password for the default user. If not set, a random one will be generated and available in the generated_user_password output variable. | string | `` | no |
+| vpc_network | Existing VPC network to which instances are connected. The networks needs to be configured with https://cloud.google.com/vpc/docs/configure-private-services-access. | string | - | yes |
+| zone | The zone for the master instance, it should be something like: `a`, `c`. | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| failover-replica\_instance\_connection\_name | The connection name of the failover-replica instance to be used in connection strings |
-| failover-replica\_instance\_name | The instance name for the failover replica instance |
-| failover-replica\_instance\_self\_link | The URI of the failover-replica instance |
-| failover-replica\_instance\_service\_account\_email\_address | The service account email addresses assigned to the failover-replica instance |
-| generated\_user\_password | The auto generated default user password if not input password was provided |
-| instance\_connection\_name | The connection name of the master instance to be used in connection strings |
-| instance\_name | The instance name for the master instance |
-| instance\_self\_link | The URI of the master instance |
-| instance\_service\_account\_email\_address | The service account email address assigned to the master instance |
-| read\_replica\_instance\_names | The instance names for the read replica instances |
-| replicas\_instance\_connection\_names | The connection names of the replica instances to be used in connection strings |
-| replicas\_instance\_self\_links | The URIs of the replica instances |
-| replicas\_instance\_service\_account\_email\_addresses | The service account email addresses assigned to the replica instances |
+| failover-replica_instance_connection_name | The connection name of the failover-replica instance to be used in connection strings |
+| failover-replica_instance_name | The instance name for the failover replica instance |
+| failover-replica_instance_self_link | The URI of the failover-replica instance |
+| failover-replica_instance_service_account_email_address | The service account email addresses assigned to the failover-replica instance |
+| generated_user_password | The auto generated default user password if not input password was provided |
+| instance_connection_name | The connection name of the master instance to be used in connection strings |
+| instance_name | The instance name for the master instance |
+| instance_self_link | The URI of the master instance |
+| instance_service_account_email_address | The service account email address assigned to the master instance |
+| read_replica_instance_names | The instance names for the read replica instances |
+| replicas_instance_connection_names | The connection names of the replica instances to be used in connection strings |
+| replicas_instance_self_links | The URIs of the replica instances |
+| replicas_instance_service_account_email_addresses | The service account email addresses assigned to the replica instances |
 
 [^]: (autogen_docs_end)

--- a/modules/safer_mysql/main.tf
+++ b/modules/safer_mysql/main.tf
@@ -70,6 +70,7 @@ module "safer_mysql" {
   // Read replica
 
   read_replica_configuration                   = "${var.read_replica_configuration}"
+  read_replica_name_suffix                     = "${var.read_replica_name_suffix}"
   read_replica_size                            = "${var.read_replica_size}"
   read_replica_tier                            = "${var.read_replica_tier}"
   read_replica_zones                           = "${var.read_replica_zones}"
@@ -96,6 +97,7 @@ module "safer_mysql" {
   ]
   // Failover replica
   failover_replica                                 = "${var.failover_replica}"
+  failover_replica_name_suffix                     = "${var.failover_replica_name_suffix}"
   failover_replica_configuration                   = "${var.failover_replica_configuration}"
   failover_replica_tier                            = "${var.failover_replica_tier}"
   failover_replica_zone                            = "${var.failover_replica_zone}"

--- a/modules/safer_mysql/variables.tf
+++ b/modules/safer_mysql/variables.tf
@@ -130,6 +130,11 @@ variable "read_replica_configuration" {
   default     = {}
 }
 
+variable "read_replica_name_suffix" {
+  description = "The optional suffix to add to the read instance name"
+  default     = ""
+}
+
 variable "read_replica_size" {
   description = "The size of read replicas"
   default     = 0
@@ -210,6 +215,11 @@ variable "read_replica_user_labels" {
 variable "failover_replica" {
   description = "Specify true if the failover instance is required"
   default     = false
+}
+
+variable "failover_replica_name_suffix" {
+  description = "The optional suffix to add to the failover instance name"
+  default     = ""
 }
 
 variable "failover_replica_configuration" {

--- a/test/fixtures/mysql-ha/main.tf
+++ b/test/fixtures/mysql-ha/main.tf
@@ -60,7 +60,7 @@ module "mysql" {
   }
 
   // Read replica configurations
-  read_replica_name_suffix                     = "test"
+  read_replica_name_suffix                     = "-test"
   read_replica_size                            = 3
   read_replica_tier                            = "db-n1-standard-1"
   read_replica_zones                           = "a,b,c"
@@ -99,7 +99,7 @@ module "mysql" {
 
   // Failover replica configurations
   failover_replica                                 = true
-  failover_replica_name_suffix                     = "test"
+  failover_replica_name_suffix                     = "-test"
   failover_replica_tier                            = "db-n1-standard-1"
   failover_replica_zone                            = "a"
   failover_replica_activation_policy               = "ALWAYS"

--- a/test/fixtures/mysql-ha/main.tf
+++ b/test/fixtures/mysql-ha/main.tf
@@ -60,6 +60,7 @@ module "mysql" {
   }
 
   // Read replica configurations
+  read_replica_name_suffix                     = "test"
   read_replica_size                            = 3
   read_replica_tier                            = "db-n1-standard-1"
   read_replica_zones                           = "a,b,c"
@@ -98,6 +99,7 @@ module "mysql" {
 
   // Failover replica configurations
   failover_replica                                 = true
+  failover_replica_name_suffix                     = "test"
   failover_replica_tier                            = "db-n1-standard-1"
   failover_replica_zone                            = "a"
   failover_replica_activation_policy               = "ALWAYS"

--- a/test/fixtures/postgresql-ha/main.tf
+++ b/test/fixtures/postgresql-ha/main.tf
@@ -60,7 +60,7 @@ module "pg" {
   }
 
   // Read replica configurations
-  read_replica_name_suffix                     = "test"
+  read_replica_name_suffix                     = "-test"
   read_replica_size                            = 3
   read_replica_tier                            = "db-custom-2-13312"
   read_replica_zones                           = "a,b,c"

--- a/test/fixtures/postgresql-ha/main.tf
+++ b/test/fixtures/postgresql-ha/main.tf
@@ -60,6 +60,7 @@ module "pg" {
   }
 
   // Read replica configurations
+  read_replica_name_suffix                     = "test"
   read_replica_size                            = 3
   read_replica_tier                            = "db-custom-2-13312"
   read_replica_zones                           = "a,b,c"

--- a/test/integration/mysql-ha/controls/mysql.rb
+++ b/test/integration/mysql-ha/controls/mysql.rb
@@ -57,7 +57,7 @@ describe google_sql_database_instance(project: project_id, database: basename) d
   it { expect(user_labels).to include(foo: "bar") }
 end
 
-describe google_sql_database_instance(project: project_id, database: "#{basename}-failover") do
+describe google_sql_database_instance(project: project_id, database: "#{basename}-failover-test") do
   let(:expected_settings) {
     {
       activation_policy: "ALWAYS",
@@ -93,7 +93,7 @@ describe google_sql_database_instance(project: project_id, database: "#{basename
 end
 
 %i[a b c].each_with_index do |zone, index|
-  name = "#{basename}-replica#{index}"
+  name = "#{basename}-replica-test#{index}"
   describe google_sql_database_instance(project: project_id, database: name) do
     let(:expected_settings) {
       {

--- a/test/integration/postgresql-ha/controls/pg.rb
+++ b/test/integration/postgresql-ha/controls/pg.rb
@@ -59,7 +59,7 @@ describe google_sql_database_instance(project: project_id, database: basename) d
 end
 
 %i[a b c].each_with_index do |zone, index|
-  name = "#{basename}-replica#{index}"
+  name = "#{basename}-replica-test#{index}"
   describe google_sql_database_instance(project: project_id, database: name) do
     let(:expected_settings) {
       {


### PR DESCRIPTION
To do this, this commit allows you to set the suffix for replicas.
Fixes #44

@morgante @aaron-lane  @wadefrancis could you take a look?